### PR TITLE
fix: updated criteria for forceUpdate function

### DIFF
--- a/src/react/Editor.tsx
+++ b/src/react/Editor.tsx
@@ -137,7 +137,11 @@ export class Editor extends React.Component<EditorProps> {
     }
 
     // Ensures `value` given to this component is always reflected in the editor
-    if (this.props.value !== this.editor.state.sliceDoc(0)) {
+    // Only execute forceUpdate actions on readonly instances
+    if (
+      this.props.value !== this.editor.state.sliceDoc(0) &&
+      this.props.readonly
+    ) {
       this.editor.forceUpdate(this.props.value);
     }
 


### PR DESCRIPTION
Changes to an editor (such as typing) can trigger a forceUpdate function on the <Editor />

When the forceUpdate function is triggered, it replaces all content within the editor with the provided value and looses its cursor position, as it is reset to the start of the document.

This PR change ensure that the forceUpdate function is only triggered on `readonly` editors, such as a json editor where results are displayed. To prevent the function from being triggered by interactions with non `readonly` editor instances.