### PR TITLE
fix: ability to update readonly mode at run time

### DIFF
--- a/src/editor/base-editor.ts
+++ b/src/editor/base-editor.ts
@@ -3,6 +3,7 @@ import throttle from "lodash/throttle";
 import {
   setDimensions,
   setHighlightStyle,
+  setReadOnly,
   setTheme,
   ThemeName,
 } from "../extensions/appearance";
@@ -37,6 +38,10 @@ export abstract class BaseEditor {
   public setTheme = (theme?: ThemeName) => {
     this.view.dispatch(setTheme(theme));
     this.view.dispatch(setHighlightStyle(theme));
+  };
+
+  public setReadOnly = (readOnly: boolean) => {
+    this.view.dispatch(setReadOnly(readOnly));
   };
 
   public forceUpdate = (code: string = "") => {

--- a/src/editor/ts-editor.ts
+++ b/src/editor/ts-editor.ts
@@ -1,6 +1,12 @@
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { appearance, setTheme, ThemeName } from "../extensions/appearance";
+import {
+  appearance,
+  editable,
+  setReadOnly,
+  setTheme,
+  ThemeName,
+} from "../extensions/appearance";
 import { behaviour } from "../extensions/behaviour";
 import { keymap as defaultKeymap } from "../extensions/keymap";
 import * as PrismaQuery from "../extensions/prisma-query";
@@ -33,12 +39,13 @@ export class TSEditor extends BaseEditor {
   /**
    * Returns a state-only version of the editor, without mounting the actual view anywhere. Useful for testing.
    */
+
   static state(params: TSEditorParams) {
     return EditorState.create({
       doc: params.code || "",
 
       extensions: [
-        EditorView.editable.of(!params.readonly),
+        editable({ readOnly: !params.readonly }),
 
         appearance({
           domElement: params.domElement,
@@ -81,6 +88,11 @@ export class TSEditor extends BaseEditor {
   public setTheme = (theme?: ThemeName) => {
     // Override the `setTheme` method to make sure `highlightStyle` never changes from "none"
     this.view.dispatch(setTheme(theme));
+  };
+
+  /** @override */
+  public setReadOnly = (readOnly: boolean) => {
+    this.view.dispatch(setReadOnly(readOnly));
   };
 
   public injectTypes = async (types: FileMap) => {

--- a/src/extensions/appearance/index.ts
+++ b/src/extensions/appearance/index.ts
@@ -20,6 +20,7 @@ export type HighlightStyle = "light" | "dark" | "none";
 const dimensionsCompartment = new Compartment();
 const themeCompartment = new Compartment();
 const highlightStyleCompartment = new Compartment();
+const editableCompartment = new Compartment();
 
 const getThemeExtension = (t: ThemeName = "light"): Extension => {
   if (t === "light") {
@@ -45,6 +46,12 @@ export const setTheme = (theme?: ThemeName): TransactionSpec => {
   };
 };
 
+export const setReadOnly = (readOnly: boolean): TransactionSpec => {
+  return {
+    effects: editableCompartment.reconfigure(EditorView.editable.of(!readOnly)),
+  };
+};
+
 export const setHighlightStyle = (
   highlightStyle?: HighlightStyle
 ): TransactionSpec => {
@@ -67,6 +74,9 @@ export const setDimensions = (
     ),
   };
 };
+
+export const editable = ({ readOnly }: { readOnly: boolean }): Extension =>
+  editableCompartment.of(EditorView.editable.of(readOnly));
 
 export const appearance = ({
   domElement,

--- a/src/react/Editor.tsx
+++ b/src/react/Editor.tsx
@@ -135,6 +135,12 @@ export class Editor extends React.Component<EditorProps> {
     if (!this.editor) {
       return;
     }
+    if (
+      typeof this.props.readonly !== "undefined" &&
+      prevProps.readonly !== this.props.readonly
+    ) {
+      this.editor.setReadOnly(this.props.readonly);
+    }
 
     // Ensures `value` given to this component is always reflected in the editor
     // Only execute forceUpdate actions on readonly instances


### PR DESCRIPTION
Part 1 of CP-1373

This PR adds the ability to change the mode from read only at runtime / after initialization of the editor.